### PR TITLE
feat: add CUDA graph support for speech tokenizer decoder

### DIFF
--- a/vllm_omni/model_executor/models/qwen3_tts/cuda_graph_decoder_wrapper.py
+++ b/vllm_omni/model_executor/models/qwen3_tts/cuda_graph_decoder_wrapper.py
@@ -1,0 +1,285 @@
+# Copyright 2026 The Alibaba Qwen team.
+# SPDX-License-Identifier: Apache-2.0
+"""
+CUDA Graph wrapper for Qwen3TTSTokenizerV2Decoder.
+
+This module provides CUDA Graph acceleration for the speech tokenizer decoder,
+reducing kernel launch overhead during inference.
+"""
+
+import torch
+from torch.cuda import CUDAGraph
+from typing import Dict, List, Optional, Tuple
+from vllm.logger import init_logger
+
+logger = init_logger(__name__)
+
+
+class CUDAGraphDecoderWrapper:
+    """
+    CUDA Graph wrapper for Qwen3TTSTokenizerV2Decoder.
+
+    This wrapper captures the decoder forward pass for fixed input sizes
+    and replays them during inference to reduce kernel launch overhead.
+
+    Usage:
+        wrapper = CUDAGraphDecoderWrapper(decoder, capture_sizes=[25, 50, 100, 200, 300])
+        wrapper.warmup(device)
+
+        # During inference:
+        output = wrapper.decode(codes)  # Automatically uses CUDA graph if possible
+    """
+
+    # Default capture sizes (in terms of code sequence length)
+    # These should cover common chunk sizes used in chunked_decode
+    DEFAULT_CAPTURE_SIZES = [25, 50, 100, 150, 200, 250, 300, 400, 500]
+
+    def __init__(
+        self,
+        decoder: torch.nn.Module,
+        capture_sizes: Optional[List[int]] = None,
+        num_quantizers: int = 8,
+        enabled: bool = True,
+    ):
+        """
+        Initialize the CUDA Graph wrapper.
+
+        Args:
+            decoder: The Qwen3TTSTokenizerV2Decoder module
+            capture_sizes: List of code sequence lengths to capture graphs for
+            num_quantizers: Number of quantizers (codebook layers)
+            enabled: Whether CUDA graph is enabled
+        """
+        self.decoder = decoder
+        self.capture_sizes = capture_sizes or self.DEFAULT_CAPTURE_SIZES
+        self.num_quantizers = num_quantizers
+        self.enabled = enabled
+
+        # CUDA graph storage
+        self.graphs: Dict[int, CUDAGraph] = {}
+        self.static_inputs: Dict[int, torch.Tensor] = {}
+        self.static_outputs: Dict[int, torch.Tensor] = {}
+
+        self._warmed_up = False
+        self._device = None
+
+    def _get_padded_size(self, actual_size: int) -> Optional[int]:
+        """
+        Get the smallest capture size that can accommodate the actual size.
+
+        Args:
+            actual_size: The actual code sequence length
+
+        Returns:
+            The padded size, or None if no suitable size exists
+        """
+        for size in self.capture_sizes:
+            if actual_size <= size:
+                return size
+        return None
+
+    def warmup(self, device: torch.device, dtype: torch.dtype = torch.long):
+        """
+        Warmup: capture CUDA graphs for all predefined sizes.
+
+        This should be called once during model initialization.
+
+        Args:
+            device: The device to capture graphs on
+            dtype: Data type for input codes (usually torch.long)
+        """
+        if not self.enabled:
+            logger.info("CUDA Graph is disabled, skipping warmup")
+            return
+
+        if self._warmed_up:
+            logger.warning("CUDA Graph already warmed up, skipping")
+            return
+
+        self._device = device
+        self.decoder.eval()
+
+        logger.info(f"Starting CUDA Graph warmup for {len(self.capture_sizes)} sizes: {self.capture_sizes}")
+
+        # Warmup runs to ensure CUDA memory is allocated
+        for size in self.capture_sizes:
+            dummy_codes = torch.zeros(
+                1, self.num_quantizers, size,
+                dtype=dtype,
+                device=device
+            )
+            with torch.no_grad():
+                _ = self.decoder(dummy_codes)
+
+        # Synchronize before capturing
+        torch.cuda.synchronize(device)
+
+        # Capture graphs for each size
+        for size in self.capture_sizes:
+            try:
+                self._capture_graph_for_size(size, device, dtype)
+                logger.info(f"  Captured CUDA Graph for size={size}")
+            except Exception as e:
+                logger.warning(f"  Failed to capture CUDA Graph for size={size}: {e}")
+                # Continue with other sizes
+
+        self._warmed_up = True
+        logger.info(f"CUDA Graph warmup complete. Captured {len(self.graphs)} graphs.")
+
+    def _capture_graph_for_size(
+        self,
+        size: int,
+        device: torch.device,
+        dtype: torch.dtype
+    ):
+        """
+        Capture a CUDA graph for a specific input size.
+
+        Args:
+            size: Code sequence length
+            device: Device to capture on
+            dtype: Input dtype
+        """
+        # Create static input buffer
+        static_input = torch.zeros(
+            1, self.num_quantizers, size,
+            dtype=dtype,
+            device=device
+        )
+
+        # Warmup run (required before capture)
+        with torch.no_grad():
+            _ = self.decoder(static_input)
+
+        torch.cuda.synchronize(device)
+
+        # Capture the graph
+        graph = CUDAGraph()
+        with torch.cuda.graph(graph):
+            static_output = self.decoder(static_input)
+
+        # Store everything
+        self.graphs[size] = graph
+        self.static_inputs[size] = static_input
+        self.static_outputs[size] = static_output
+
+    def decode(self, codes: torch.Tensor) -> torch.Tensor:
+        """
+        Decode codes to audio using CUDA graph if possible.
+
+        Args:
+            codes: Input codes tensor of shape (batch, num_quantizers, seq_len)
+
+        Returns:
+            Decoded audio tensor
+        """
+        if not self.enabled or not self._warmed_up:
+            return self.decoder(codes)
+
+        # Only support batch size 1 for now
+        if codes.shape[0] != 1:
+            logger.debug("Batch size > 1, falling back to eager execution")
+            return self.decoder(codes)
+
+        actual_size = codes.shape[-1]
+        padded_size = self._get_padded_size(actual_size)
+
+        if padded_size is None or padded_size not in self.graphs:
+            # Size too large or not captured, fall back to eager
+            logger.debug(f"Size {actual_size} not captured, falling back to eager execution")
+            return self.decoder(codes)
+
+        # Copy input to static buffer (with padding if needed)
+        self.static_inputs[padded_size].zero_()
+        self.static_inputs[padded_size][:, :, :actual_size] = codes
+
+        # Replay the graph
+        self.graphs[padded_size].replay()
+
+        # Get output and trim to actual size
+        output = self.static_outputs[padded_size]
+
+        # Calculate actual output length based on upsample ratio
+        total_upsample = self.decoder.total_upsample
+        actual_output_len = actual_size * total_upsample
+
+        return output[..., :actual_output_len].clone()
+
+    def chunked_decode_with_cudagraph(
+        self,
+        codes: torch.Tensor,
+        chunk_size: int = 300,
+        left_context_size: int = 25
+    ) -> torch.Tensor:
+        """
+        Chunked decode with CUDA graph acceleration.
+
+        This replaces the original chunked_decode method with CUDA graph support.
+
+        Args:
+            codes: Input codes tensor of shape (batch, num_quantizers, seq_len)
+            chunk_size: Size of each chunk
+            left_context_size: Context size for overlap
+
+        Returns:
+            Decoded audio tensor
+        """
+        wavs = []
+        start_index = 0
+        total_len = codes.shape[-1]
+        total_upsample = self.decoder.total_upsample
+
+        while start_index < total_len:
+            end_index = min(start_index + chunk_size, total_len)
+            context_size = left_context_size if start_index - left_context_size > 0 else start_index
+
+            # Extract chunk with context
+            codes_chunk = codes[..., start_index - context_size : end_index]
+
+            # Decode using CUDA graph
+            wav_chunk = self.decode(codes_chunk)
+
+            # Trim context from output
+            wavs.append(wav_chunk[..., context_size * total_upsample :])
+            start_index = end_index
+
+        return torch.cat(wavs, dim=-1)
+
+
+def patch_decoder_with_cudagraph(
+    decoder: torch.nn.Module,
+    capture_sizes: Optional[List[int]] = None,
+    enabled: bool = True,
+) -> CUDAGraphDecoderWrapper:
+    """
+    Patch a Qwen3TTSTokenizerV2Decoder with CUDA graph support.
+
+    This is a convenience function to easily add CUDA graph support to an existing decoder.
+
+    Args:
+        decoder: The decoder module to patch
+        capture_sizes: List of sizes to capture graphs for
+        enabled: Whether to enable CUDA graph
+
+    Returns:
+        CUDAGraphDecoderWrapper instance
+
+    Example:
+        decoder = model.speech_tokenizer.decoder
+        wrapper = patch_decoder_with_cudagraph(decoder)
+        wrapper.warmup(device)
+
+        # Replace the original chunked_decode
+        model.speech_tokenizer.decoder.chunked_decode = wrapper.chunked_decode_with_cudagraph
+    """
+    # Get num_quantizers from decoder config
+    num_quantizers = getattr(decoder.config, 'num_quantizers', 8)
+
+    wrapper = CUDAGraphDecoderWrapper(
+        decoder=decoder,
+        capture_sizes=capture_sizes,
+        num_quantizers=num_quantizers,
+        enabled=enabled,
+    )
+
+    return wrapper

--- a/vllm_omni/model_executor/models/qwen3_tts/qwen3_tts.py
+++ b/vllm_omni/model_executor/models/qwen3_tts/qwen3_tts.py
@@ -107,8 +107,34 @@ class Qwen3TTSModelForGeneration(nn.Module):
         # Store vllm_config for potential future use
         self.vllm_config = vllm_config
 
+        # Enable CUDA Graph for speech tokenizer decoder
+        self._enable_decoder_cudagraph()
+
         # Streaming state: one generator per active streaming request
         self._streaming_generators: dict[str, Generator] = {}
+
+    def _enable_decoder_cudagraph(self, device=None):
+        try:
+            inner_model = getattr(self.model, "model", None)
+            if inner_model is not None and hasattr(inner_model, "speech_tokenizer"):
+                tokenizer = inner_model.speech_tokenizer
+                if hasattr(tokenizer, "model") and hasattr(tokenizer.model, "decoder"):
+                    decoder = tokenizer.model.decoder
+                    # Determine device - use provided device or default to cuda:0
+                    if device is None:
+                        device = torch.device("cuda:0") if torch.cuda.is_available() else torch.device("cpu")
+                    # Move decoder to CUDA if not already there
+                    current_device = next(decoder.parameters()).device
+                    if current_device != device:
+                        decoder.to(device)
+                        logger.info(f"Moved decoder from {current_device} to {device}")
+                    if hasattr(decoder, "enable_cudagraph") and device.type == "cuda":
+                        decoder.enable_cudagraph(capture_sizes=[25, 50, 100, 150, 200, 250, 300])
+                        logger.info("CUDA Graph enabled for speech tokenizer decoder")
+                    elif device.type != "cuda":
+                        logger.info("CUDA Graph not enabled: decoder not on CUDA device")
+        except Exception as e:
+            logger.warning(f"Failed to enable CUDA Graph: {e}")
 
     def forward(
         self,

--- a/vllm_omni/model_executor/models/qwen3_tts/tokenizer_12hz/modeling_qwen3_tts_tokenizer_v2.py
+++ b/vllm_omni/model_executor/models/qwen3_tts/tokenizer_12hz/modeling_qwen3_tts_tokenizer_v2.py
@@ -848,6 +848,36 @@ class Qwen3TTSTokenizerV2Decoder(Qwen3TTSTokenizerV2DecoderPreTrainedModel):
 
         self.post_init()
 
+        # CUDA Graph support
+        self._cudagraph_enabled = False
+        self._cudagraph_wrapper = None
+
+    def enable_cudagraph(
+        self,
+        capture_sizes: list[int] | None = None,
+        device: torch.device | None = None,
+    ):
+        from ..cuda_graph_decoder_wrapper import CUDAGraphDecoderWrapper
+
+        if device is None:
+            device = next(self.parameters()).device
+
+        default_sizes = [25, 50, 100, 150, 200, 250, 300]
+        self._cudagraph_wrapper = CUDAGraphDecoderWrapper(
+            decoder=self,
+            capture_sizes=capture_sizes or default_sizes,
+            num_quantizers=self.config.num_quantizers,
+            enabled=True,
+        )
+        self._cudagraph_wrapper.warmup(device, dtype=torch.long)
+        self._cudagraph_enabled = True
+        logger.info(f"CUDA Graph enabled for decoder with sizes: {capture_sizes or default_sizes}")
+
+    def disable_cudagraph(self):
+        self._cudagraph_enabled = False
+        self._cudagraph_wrapper = None
+        logger.info("CUDA Graph disabled for decoder")
+
     def forward(self, codes):
         if codes.shape[1] != self.config.num_quantizers:
             raise ValueError(f"Expected {self.config.num_quantizers} layer of codes, got {codes.shape[1]}")
@@ -866,6 +896,13 @@ class Qwen3TTSTokenizerV2Decoder(Qwen3TTSTokenizerV2DecoderPreTrainedModel):
         return wav.clamp(min=-1, max=1)
 
     def chunked_decode(self, codes, chunk_size=300, left_context_size=25):
+        # Use CUDA graph if enabled
+        if self._cudagraph_enabled and self._cudagraph_wrapper is not None:
+            return self._cudagraph_wrapper.chunked_decode_with_cudagraph(
+                codes, chunk_size, left_context_size
+            )
+
+        # Original implementation (eager mode)
         wavs = []
         start_index = 0
         while start_index < codes.shape[-1]:


### PR DESCRIPTION
## Summary
- Cherry-pick of upstream [vllm-project/vllm-omni#1205](https://github.com/vllm-project/vllm-omni/pull/1205)
- Adds `CUDAGraphDecoderWrapper` that captures and replays CUDA graphs for the speech tokenizer decoder at fixed input sizes (25-300)
- Falls back to eager mode for unsupported sizes or non-CUDA devices
- Transparently hooks into `chunked_decode` — both streaming and non-streaming paths benefit

## Expected improvement
- ~26% latency reduction on the decoder stage (measured on H200 in upstream PR)
- Throughput up ~36%

## Changes
- New: `cuda_graph_decoder_wrapper.py` (285 lines)
- Modified: `qwen3_tts.py` — adds `_enable_decoder_cudagraph()` call during init
- Modified: `modeling_qwen3_tts_tokenizer_v2.py` — adds `enable_cudagraph()`/`disable_cudagraph()` methods

## Test plan
- [ ] Docker test with `Qwen/Qwen3-TTS-12Hz-1.7B-Base`
- [ ] Verify streaming output works with CUDA graphs enabled
- [ ] Compare latency with/without CUDA graphs

🤖 Generated with [Claude Code](https://claude.com/claude-code)