### PR TITLE
feat(qwen3-tts): entropy-based degeneration guardrail for AR talker

### DIFF
--- a/tests/e2e/test_entropy_guardrail_e2e.py
+++ b/tests/e2e/test_entropy_guardrail_e2e.py
@@ -1,0 +1,261 @@
+"""End-to-end test for the entropy guardrail sentinel trailer.
+
+Requires a running vllm-omni server with Qwen3-TTS and entropy guardrail support.
+Set VLLM_BASE_URL env var (default: http://localhost:30185).
+
+Usage:
+    python tests/e2e/test_entropy_guardrail_e2e.py [--base-url URL]
+"""
+
+import argparse
+import base64
+import json
+import os
+import struct
+import sys
+from pathlib import Path
+
+import requests
+
+SENTINEL_MAGIC = b"\x00" * 8 + b"VLLMMETA"
+DEFAULT_BASE_URL = "http://localhost:30185"
+VOICE_PATH = Path.home() / ".local/share/tts/voices/hai.wav"
+
+
+def load_ref_audio_base64(path: Path) -> str:
+    """Load audio file as base64 data URI."""
+    raw = path.read_bytes()
+    b64 = base64.b64encode(raw).decode("ascii")
+    return f"data:audio/wav;base64,{b64}"
+
+
+def parse_sentinel_trailer(data: bytes) -> dict | None:
+    """Parse sentinel trailer from end of PCM stream.
+
+    Returns the JSON metadata dict if found, None otherwise.
+    """
+    idx = data.rfind(SENTINEL_MAGIC)
+    if idx == -1:
+        return None
+    offset = idx + len(SENTINEL_MAGIC)
+    if len(data) < offset + 4:
+        return None
+    json_len = struct.unpack("<I", data[offset : offset + 4])[0]
+    json_start = offset + 4
+    if len(data) < json_start + json_len:
+        return None
+    payload = data[json_start : json_start + json_len]
+    return json.loads(payload.decode("utf-8"))
+
+
+def test_normal_completion(base_url: str, ref_audio: str) -> bool:
+    """Test that normal (non-guardrail) completion has NO sentinel."""
+    print("\n=== Test 1: Normal completion (no guardrail trigger) ===")
+    resp = requests.post(
+        f"{base_url}/v1/audio/speech",
+        json={
+            "model": "Qwen/Qwen3-TTS-12Hz-0.6B-Base",
+            "input": "Hello world.",
+            "task_type": "Base",
+            "ref_audio": ref_audio,
+            "x_vector_only_mode": True,
+            "response_format": "pcm",
+            "stream": True,
+            "entropy_guardrail": True,
+            "entropy_threshold_high": 8.0,  # very permissive — should NOT trigger
+            "entropy_threshold_low": 0.01,
+            "entropy_window": 50,
+            "max_new_tokens": 200,
+        },
+        stream=True,
+        timeout=120,
+    )
+    resp.raise_for_status()
+
+    # Check for X-TTS-Trailer header
+    has_trailer_header = resp.headers.get("X-TTS-Trailer") == "supported"
+    print(f"  X-TTS-Trailer header: {has_trailer_header}")
+
+    data = b""
+    for chunk in resp.iter_content(chunk_size=4096):
+        data += chunk
+    print(f"  Received {len(data)} bytes of audio")
+
+    meta = parse_sentinel_trailer(data)
+    if meta is None:
+        print("  PASS: No sentinel trailer (normal completion)")
+        return True
+    else:
+        print(f"  FAIL: Unexpected sentinel trailer: {meta}")
+        return False
+
+
+def test_guardrail_trigger_streaming(base_url: str, ref_audio: str) -> bool:
+    """Test that tight guardrail thresholds trigger and produce sentinel."""
+    print("\n=== Test 2: Streaming with tight guardrail (should trigger) ===")
+    resp = requests.post(
+        f"{base_url}/v1/audio/speech",
+        json={
+            "model": "Qwen/Qwen3-TTS-12Hz-0.6B-Base",
+            "input": "This is a longer sentence to give the model time to potentially trigger the entropy guardrail with very tight thresholds set for testing purposes.",
+            "task_type": "Base",
+            "ref_audio": ref_audio,
+            "x_vector_only_mode": True,
+            "response_format": "pcm",
+            "stream": True,
+            "entropy_guardrail": True,
+            "entropy_threshold_high": 2.0,  # very tight — should trigger quickly
+            "entropy_threshold_low": 2.0,  # impossible range — guarantees trigger
+            "entropy_window": 2,
+            "max_new_tokens": 2000,
+        },
+        stream=True,
+        timeout=120,
+    )
+    resp.raise_for_status()
+
+    has_trailer_header = resp.headers.get("X-TTS-Trailer") == "supported"
+    print(f"  X-TTS-Trailer header: {has_trailer_header}")
+
+    data = b""
+    for chunk in resp.iter_content(chunk_size=4096):
+        data += chunk
+    print(f"  Received {len(data)} bytes")
+
+    meta = parse_sentinel_trailer(data)
+    if meta is not None:
+        print("  PASS: Sentinel trailer found!")
+        print(f"    reason: {meta.get('reason')}")
+        print(f"    step: {meta.get('step')}")
+        print(f"    entropy: {meta.get('entropy')}")
+        print(f"    threshold: {meta.get('threshold')}")
+        print(f"    window: {meta.get('window')}")
+        # Strip trailer and check audio is still valid PCM
+        idx = data.rfind(SENTINEL_MAGIC)
+        audio_only = data[:idx]
+        print(f"    Audio bytes (without trailer): {len(audio_only)}")
+        return True
+    else:
+        print("  FAIL: No sentinel trailer found (guardrail may not have triggered)")
+        print("  Note: this could mean metadata didn't survive the pipeline")
+        return False
+
+
+def test_guardrail_nonstreaming(base_url: str, ref_audio: str) -> bool:
+    """Test that non-streaming response gets X-TTS-Guardrail header."""
+    print("\n=== Test 3: Non-streaming with tight guardrail (header check) ===")
+    resp = requests.post(
+        f"{base_url}/v1/audio/speech",
+        json={
+            "model": "Qwen/Qwen3-TTS-12Hz-0.6B-Base",
+            "input": "Testing the non-streaming guardrail header response.",
+            "task_type": "Base",
+            "ref_audio": ref_audio,
+            "x_vector_only_mode": True,
+            "response_format": "wav",
+            "stream": False,
+            "entropy_guardrail": True,
+            "entropy_threshold_high": 2.0,
+            "entropy_threshold_low": 2.0,
+            "entropy_window": 2,
+            "max_new_tokens": 2000,
+        },
+        timeout=120,
+    )
+    resp.raise_for_status()
+
+    guardrail_header = resp.headers.get("X-TTS-Guardrail")
+    print(f"  X-TTS-Guardrail header: {guardrail_header}")
+    print(f"  Received {len(resp.content)} bytes of audio")
+
+    if guardrail_header:
+        meta = json.loads(guardrail_header)
+        print("  PASS: Guardrail header found!")
+        print(f"    reason: {meta.get('reason')}")
+        print(f"    step: {meta.get('step')}")
+        return True
+    else:
+        print("  FAIL: No X-TTS-Guardrail header")
+        return False
+
+
+def test_no_guardrail_no_trailer(base_url: str, ref_audio: str) -> bool:
+    """Test that with guardrail disabled, no sentinel or header appears."""
+    print("\n=== Test 4: Guardrail disabled (no trailer or header) ===")
+    resp = requests.post(
+        f"{base_url}/v1/audio/speech",
+        json={
+            "model": "Qwen/Qwen3-TTS-12Hz-0.6B-Base",
+            "input": "Short test.",
+            "task_type": "Base",
+            "ref_audio": ref_audio,
+            "x_vector_only_mode": True,
+            "response_format": "pcm",
+            "stream": True,
+            "entropy_guardrail": False,
+            "max_new_tokens": 200,
+        },
+        stream=True,
+        timeout=120,
+    )
+    resp.raise_for_status()
+
+    has_trailer_header = resp.headers.get("X-TTS-Trailer")
+    data = b""
+    for chunk in resp.iter_content(chunk_size=4096):
+        data += chunk
+
+    meta = parse_sentinel_trailer(data)
+    if meta is None and not has_trailer_header:
+        print("  PASS: No trailer or header (guardrail disabled)")
+        return True
+    else:
+        print(f"  FAIL: Unexpected trailer={meta}, header={has_trailer_header}")
+        return False
+
+
+def main():
+    parser = argparse.ArgumentParser(description="E2E test for entropy guardrail sentinel")
+    parser.add_argument("--base-url", default=os.environ.get("VLLM_BASE_URL", DEFAULT_BASE_URL))
+    parser.add_argument("--voice", default=str(VOICE_PATH))
+    args = parser.parse_args()
+
+    voice_path = Path(args.voice)
+    if not voice_path.exists():
+        print(f"Voice file not found: {voice_path}")
+        sys.exit(1)
+
+    ref_audio = load_ref_audio_base64(voice_path)
+    print(f"Using server: {args.base_url}")
+    print(f"Using voice: {voice_path}")
+
+    # Check server is up
+    try:
+        r = requests.get(f"{args.base_url}/v1/models", timeout=5)
+        r.raise_for_status()
+        models = r.json()
+        print(f"Server models: {[m['id'] for m in models.get('data', [])]}")
+    except Exception as e:
+        print(f"Server not reachable at {args.base_url}: {e}")
+        sys.exit(1)
+
+    results = []
+    results.append(("Normal completion (no trigger)", test_normal_completion(args.base_url, ref_audio)))
+    results.append(("Streaming guardrail trigger", test_guardrail_trigger_streaming(args.base_url, ref_audio)))
+    results.append(("Non-streaming guardrail header", test_guardrail_nonstreaming(args.base_url, ref_audio)))
+    results.append(("Guardrail disabled", test_no_guardrail_no_trailer(args.base_url, ref_audio)))
+
+    print("\n" + "=" * 60)
+    print("RESULTS:")
+    passed = 0
+    for name, ok in results:
+        status = "PASS" if ok else "FAIL"
+        print(f"  [{status}] {name}")
+        if ok:
+            passed += 1
+    print(f"\n{passed}/{len(results)} tests passed")
+    sys.exit(0 if passed == len(results) else 1)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/model_executor/test_entropy_guardrail.py
+++ b/tests/model_executor/test_entropy_guardrail.py
@@ -1,0 +1,406 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+"""Unit tests for the entropy-based degeneration guardrail in Qwen3TTSTalker.
+
+The guardrail method ``_apply_entropy_guardrail`` lives on
+``Qwen3TTSTalkerForCausalLM`` which has a heavy import chain (vllm, librosa,
+etc.).  To keep these tests lightweight and runnable without a full install we
+build a thin shim that carries only the fields the method reads and bind the
+method source directly via ``types.FunctionType``.
+
+No GPU, no model weights, no server required.
+"""
+
+from __future__ import annotations
+
+import ast
+import logging
+import types
+from pathlib import Path
+from typing import Any
+
+import torch
+import torch.nn.functional as F  # noqa: N812 – the method body uses F
+
+# ---------------------------------------------------------------------------
+# Extract ``_apply_entropy_guardrail`` source from the talker module without
+# importing it (which would pull in vllm, librosa, …).
+# ---------------------------------------------------------------------------
+
+_TALKER_PATH = (
+    Path(__file__).resolve().parents[2]
+    / "vllm_omni"
+    / "model_executor"
+    / "models"
+    / "qwen3_tts"
+    / "qwen3_tts_talker.py"
+)
+
+
+def _extract_method(source_path: Path, method_name: str):
+    """Parse the source file's AST and compile just the target method."""
+    tree = ast.parse(source_path.read_text())
+    for node in ast.walk(tree):
+        if isinstance(node, ast.FunctionDef) and node.name == method_name:
+            # Wrap in a module so compile() is happy
+            mod = ast.Module(body=[node], type_ignores=[])
+            ast.fix_missing_locations(mod)
+            code = compile(mod, str(source_path), "exec")
+            ns: dict[str, Any] = {"torch": torch, "F": F, "logger": logging.getLogger("entropy_guardrail_test")}
+            exec(code, ns)  # noqa: S102
+            return ns[method_name]
+    raise ValueError(f"{method_name} not found in {source_path}")
+
+
+_guardrail_fn = _extract_method(_TALKER_PATH, "_apply_entropy_guardrail")
+
+# ---------------------------------------------------------------------------
+# Minimal shim that carries only the state _apply_entropy_guardrail touches.
+# ---------------------------------------------------------------------------
+
+VOCAB_SIZE = 256  # large enough that uniform entropy (~5.5) exceeds default thresholds
+EOS_ID = 0  # treat token-0 as codec EOS
+
+logger = logging.getLogger("vllm_omni.model_executor.models.qwen3_tts.qwen3_tts_talker")
+
+
+class _GuardrailShim:
+    """Mimics just the fields that ``_apply_entropy_guardrail`` reads."""
+
+    def __init__(
+        self,
+        *,
+        eos_id: int = EOS_ID,
+        enabled: bool = True,
+        threshold_high: float = 4.5,
+        threshold_low: float = 0.5,
+        window: int = 5,
+    ):
+        self._codec_eos_token_id = eos_id
+        self._entropy_state: dict[int, dict[str, Any]] = {}
+        self._entropy_defaults: dict[str, Any] = {
+            "enabled": enabled,
+            "threshold_high": threshold_high,
+            "threshold_low": threshold_low,
+            "window": window,
+        }
+        self._entropy_config_staging: list[dict[str, Any]] = []
+        self._entropy_guardrail_triggered: dict[int, dict[str, Any]] = {}
+
+    def _apply_entropy_guardrail(self, logits, sampling_metadata):
+        return _guardrail_fn(self, logits, sampling_metadata)
+
+
+def _sampling_meta(output_token_ids: list[list[int]]):
+    return types.SimpleNamespace(output_token_ids=output_token_ids)
+
+
+def _uniform_logits(batch: int = 1, vocab: int = VOCAB_SIZE) -> torch.Tensor:
+    """Logits that produce ~uniform distribution -> high entropy."""
+    return torch.zeros(batch, vocab)
+
+
+def _peaked_logits(batch: int = 1, vocab: int = VOCAB_SIZE, peak_id: int = 5) -> torch.Tensor:
+    """Logits that produce a very peaked distribution -> very low entropy."""
+    logits = torch.full((batch, vocab), -20.0)
+    logits[:, peak_id] = 20.0
+    return logits
+
+
+def _normal_logits(batch: int = 1, vocab: int = VOCAB_SIZE) -> torch.Tensor:
+    """Logits with moderate entropy (within default thresholds ~1-3 nats)."""
+    # Create a distribution that's peaked enough to keep entropy in [1, 3.5]
+    logits = torch.full((batch, vocab), -10.0)
+    # Spread probability mass over ~10 tokens
+    for i in range(10):
+        logits[:, i] = torch.randn(batch) + 2.0
+    return logits
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestEntropyGuardrailBasics:
+    """Core behaviour: trigger on sustained OOB, recover when in-bounds."""
+
+    def test_disabled_by_default_is_noop(self):
+        shim = _GuardrailShim(enabled=False)
+        tokens = [list(range(10))]
+        logits = _uniform_logits()
+        meta = _sampling_meta(tokens)
+        result = shim._apply_entropy_guardrail(logits, meta)
+        assert torch.equal(result, logits), "Disabled guardrail should not modify logits"
+
+    def test_early_steps_skipped(self):
+        """Steps < 2 should be skipped (no meaningful entropy)."""
+        shim = _GuardrailShim(enabled=True, window=1)
+        tokens = [[42]]  # only 1 token so far
+        logits = _uniform_logits()
+        meta = _sampling_meta(tokens)
+        result = shim._apply_entropy_guardrail(logits, meta)
+        assert torch.equal(result, logits), "Step < 2 should be skipped"
+
+    def test_no_output_token_ids_is_noop(self):
+        shim = _GuardrailShim(enabled=True)
+        logits = _uniform_logits()
+        meta = types.SimpleNamespace(output_token_ids=None)
+        result = shim._apply_entropy_guardrail(logits, meta)
+        assert torch.equal(result, logits)
+
+    def test_missing_attr_is_noop(self):
+        shim = _GuardrailShim(enabled=True)
+        logits = _uniform_logits()
+        meta = types.SimpleNamespace()
+        result = shim._apply_entropy_guardrail(logits, meta)
+        assert torch.equal(result, logits)
+
+
+class TestHighEntropyTrigger:
+    """Sustained high entropy (uniform logits) should force EOS."""
+
+    def test_forces_eos_after_window_exceeded(self):
+        window = 3
+        shim = _GuardrailShim(enabled=True, threshold_high=4.0, window=window)
+        tokens = [list(range(10))]
+        meta = _sampling_meta(tokens)
+
+        triggered = False
+        for step in range(window + 2):
+            tokens[0].append(99)
+            logits = _uniform_logits()
+            result = shim._apply_entropy_guardrail(logits, meta)
+            if result[0, EOS_ID] == 100.0:
+                triggered = True
+                break
+
+        assert triggered, "EOS should have been forced after window consecutive OOB steps"
+        for tok_id in range(VOCAB_SIZE):
+            if tok_id != EOS_ID:
+                assert result[0, tok_id] == float("-inf"), f"Non-EOS token {tok_id} should be -inf"
+
+    def test_resets_after_trigger(self):
+        """After triggering, the consecutive counter resets so it doesn't
+        fire again immediately on the very next step."""
+        window = 2
+        shim = _GuardrailShim(enabled=True, threshold_high=4.0, window=window)
+        tokens = [list(range(10))]
+        meta = _sampling_meta(tokens)
+
+        # Trigger
+        for _ in range(window + 1):
+            tokens[0].append(99)
+            shim._apply_entropy_guardrail(_uniform_logits(), meta)
+
+        # Next step with normal logits should NOT trigger
+        tokens[0].append(99)
+        logits = _normal_logits()
+        result = shim._apply_entropy_guardrail(logits, meta)
+        assert result[0, EOS_ID] != 100.0, "Should not trigger right after reset"
+
+
+class TestLowEntropyTrigger:
+    """Sustained low entropy (peaked logits) should also force EOS."""
+
+    def test_forces_eos_on_collapsed_entropy(self):
+        window = 3
+        shim = _GuardrailShim(enabled=True, threshold_low=0.5, threshold_high=10.0, window=window)
+        tokens = [list(range(10))]
+        meta = _sampling_meta(tokens)
+
+        triggered = False
+        for _ in range(window + 2):
+            tokens[0].append(99)
+            logits = _peaked_logits()
+            result = shim._apply_entropy_guardrail(logits, meta)
+            if result[0, EOS_ID] == 100.0:
+                triggered = True
+                break
+
+        assert triggered, "Collapsed entropy should force EOS"
+
+
+class TestRecoveryWithinWindow:
+    """If entropy returns to normal before the window is exhausted, no trigger."""
+
+    def test_no_trigger_when_recovered(self):
+        window = 5
+        shim = _GuardrailShim(enabled=True, threshold_high=4.0, window=window)
+        tokens = [list(range(10))]
+        meta = _sampling_meta(tokens)
+
+        # 3 OOB steps (< window)
+        for _ in range(3):
+            tokens[0].append(99)
+            shim._apply_entropy_guardrail(_uniform_logits(), meta)
+
+        # Then recover with normal entropy
+        tokens[0].append(99)
+        result = shim._apply_entropy_guardrail(_normal_logits(), meta)
+
+        assert result[0, EOS_ID] != 100.0, "Should not trigger after recovery"
+        key = id(tokens[0])
+        assert shim._entropy_state[key]["consecutive_oob"] == 0
+
+
+class TestStagedConfig:
+    """Per-request config staging (from preprocess) is consumed correctly."""
+
+    def test_staged_config_overrides_defaults(self):
+        shim = _GuardrailShim(enabled=False)
+        shim._entropy_config_staging = [{"enabled": True, "threshold_high": 3.0, "threshold_low": 0.1, "window": 2}]
+        tokens = [list(range(10))]
+        meta = _sampling_meta(tokens)
+
+        shim._apply_entropy_guardrail(_uniform_logits(), meta)
+
+        key = id(tokens[0])
+        assert shim._entropy_state[key]["cfg"]["enabled"] is True
+        assert shim._entropy_state[key]["cfg"]["threshold_high"] == 3.0
+
+    def test_staged_config_consumed_in_order(self):
+        shim = _GuardrailShim(enabled=False)
+        shim._entropy_config_staging = [
+            {"enabled": True, "threshold_high": 3.0, "threshold_low": 0.1, "window": 2},
+            {"enabled": False, "threshold_high": 5.0, "threshold_low": 0.5, "window": 5},
+        ]
+        tokens_a = list(range(10))
+        tokens_b = list(range(10))
+        meta = _sampling_meta([tokens_a, tokens_b])
+
+        shim._apply_entropy_guardrail(_uniform_logits(batch=2), meta)
+
+        assert shim._entropy_state[id(tokens_a)]["cfg"]["enabled"] is True
+        assert shim._entropy_state[id(tokens_b)]["cfg"]["enabled"] is False
+
+
+class TestBatchHandling:
+    """Guardrail handles batches with mixed enabled/disabled requests."""
+
+    def test_only_enabled_request_triggers(self):
+        shim = _GuardrailShim(enabled=False)
+        shim._entropy_config_staging = [
+            {"enabled": True, "threshold_high": 4.0, "threshold_low": 0.5, "window": 2},
+            {"enabled": False, "threshold_high": 4.0, "threshold_low": 0.5, "window": 2},
+        ]
+        tokens_a = list(range(10))
+        tokens_b = list(range(10))
+        meta = _sampling_meta([tokens_a, tokens_b])
+
+        for _ in range(4):
+            tokens_a.append(99)
+            tokens_b.append(99)
+            logits = _uniform_logits(batch=2)
+            result = shim._apply_entropy_guardrail(logits, meta)
+
+        assert result[0, EOS_ID] == 100.0
+        assert result[1, EOS_ID] != 100.0
+
+
+class TestStaleStatePruning:
+    """Old request state is cleaned up when the batch shrinks."""
+
+    def test_stale_entries_pruned(self):
+        shim = _GuardrailShim(enabled=True, window=100)
+
+        for i in range(20):
+            fake_key = 1_000_000 + i
+            shim._entropy_state[fake_key] = {
+                "consecutive_oob": 0,
+                "last_step": 0,
+                "cfg": dict(shim._entropy_defaults),
+            }
+
+        tokens = [list(range(10))]
+        meta = _sampling_meta(tokens)
+        shim._apply_entropy_guardrail(_uniform_logits(), meta)
+
+        # 20 stale + 1 active = 21 > batch_size*2+10 = 12 -> pruning fires
+        assert len(shim._entropy_state) <= 3, f"Expected pruning, got {len(shim._entropy_state)} entries"
+
+
+class TestEdgeCases:
+    def test_invalid_eos_id_is_noop(self):
+        shim = _GuardrailShim(enabled=True, eos_id=-1)
+        tokens = [list(range(10))]
+        meta = _sampling_meta(tokens)
+        logits = _uniform_logits()
+        result = shim._apply_entropy_guardrail(logits, meta)
+        assert torch.equal(result, logits)
+
+    def test_eos_id_out_of_range_is_noop(self):
+        shim = _GuardrailShim(enabled=True, eos_id=VOCAB_SIZE + 10)
+        tokens = [list(range(10))]
+        meta = _sampling_meta(tokens)
+        logits = _uniform_logits()
+        result = shim._apply_entropy_guardrail(logits, meta)
+        assert torch.equal(result, logits)
+
+
+class TestTriggerMetadata:
+    """Verify that guardrail trigger metadata is stored correctly."""
+
+    def test_trigger_stores_metadata(self):
+        window = 2
+        shim = _GuardrailShim(enabled=True, threshold_high=4.0, window=window)
+        tokens = [list(range(10))]
+        meta = _sampling_meta(tokens)
+
+        # Run exactly `window` steps — trigger fires on the last one.
+        for _ in range(window):
+            tokens[0].append(99)
+            shim._apply_entropy_guardrail(_uniform_logits(), meta)
+
+        # Should have exactly one trigger for batch index 0
+        assert 0 in shim._entropy_guardrail_triggered
+        trigger = shim._entropy_guardrail_triggered[0]
+        assert trigger["reason"] == "high_entropy"
+        assert "step" in trigger
+        assert "entropy" in trigger
+        assert trigger["threshold"] == 4.0
+        assert trigger["window"] == window
+
+    def test_low_entropy_trigger_metadata(self):
+        window = 2
+        shim = _GuardrailShim(enabled=True, threshold_low=0.5, threshold_high=10.0, window=window)
+        tokens = [list(range(10))]
+        meta = _sampling_meta(tokens)
+
+        for _ in range(window):
+            tokens[0].append(99)
+            shim._apply_entropy_guardrail(_peaked_logits(), meta)
+
+        assert 0 in shim._entropy_guardrail_triggered
+        trigger = shim._entropy_guardrail_triggered[0]
+        assert trigger["reason"] == "low_entropy"
+        assert trigger["threshold"] == 0.5
+
+    def test_no_trigger_metadata_when_normal(self):
+        shim = _GuardrailShim(enabled=True, threshold_high=6.0, threshold_low=0.1)
+        tokens = [list(range(10))]
+        meta = _sampling_meta(tokens)
+
+        for _ in range(10):
+            tokens[0].append(99)
+            shim._apply_entropy_guardrail(_normal_logits(), meta)
+
+        assert len(shim._entropy_guardrail_triggered) == 0
+
+    def test_trigger_metadata_cleared_each_step(self):
+        """Each call to _apply_entropy_guardrail resets the trigger dict."""
+        window = 2
+        shim = _GuardrailShim(enabled=True, threshold_high=4.0, window=window)
+        tokens = [list(range(10))]
+        meta = _sampling_meta(tokens)
+
+        # Trigger
+        for _ in range(window + 1):
+            tokens[0].append(99)
+            shim._apply_entropy_guardrail(_uniform_logits(), meta)
+
+        # Next step should clear the trigger dict (even if not triggered again)
+        tokens[0].append(99)
+        shim._apply_entropy_guardrail(_normal_logits(), meta)
+        assert len(shim._entropy_guardrail_triggered) == 0

--- a/vllm_omni/core/sched/omni_ar_scheduler.py
+++ b/vllm_omni/core/sched/omni_ar_scheduler.py
@@ -275,6 +275,18 @@ class OmniARScheduler(VLLMScheduler):
             new_token_ids = generated_token_ids
             pooler_output = pooler_outputs[req_index] if pooler_outputs else None
             kv_transfer_params = None
+
+            # Extract entropy guardrail trigger metadata from pooler_output.
+            # Stored temporarily; applied AFTER _update_request_with_output
+            # because check_stop overwrites stop_reason with the EOS token ID.
+            _guardrail_stop_reason = None
+            if isinstance(pooler_output, dict) and "entropy_guardrail_triggered" in pooler_output:
+                gt = pooler_output.pop("entropy_guardrail_triggered")
+                if hasattr(gt, "numpy"):
+                    gt = gt.numpy()
+                if hasattr(gt, "tobytes"):
+                    _guardrail_stop_reason = "entropy_guardrail:" + gt.tobytes().decode("utf-8")
+
             status_before_stop = request.status
             finish_reason = None
             routed_experts = None
@@ -282,6 +294,11 @@ class OmniARScheduler(VLLMScheduler):
             # Check for stop and update request status.
             if new_token_ids:
                 new_token_ids, stopped = self._update_request_with_output(request, new_token_ids)
+
+            # Apply guardrail stop_reason AFTER check_stop (which overwrites
+            # stop_reason with the EOS/stop token ID).
+            if _guardrail_stop_reason is not None:
+                request.stop_reason = _guardrail_stop_reason
             elif request.pooling_params and pooler_output is not None:
                 # Pooling stops as soon as there is output.
                 request.status = RequestStatus.FINISHED_STOPPED

--- a/vllm_omni/entrypoints/omni_base.py
+++ b/vllm_omni/entrypoints/omni_base.py
@@ -250,6 +250,17 @@ class OmniBase:
         peak_memory_mb = getattr(result["engine_outputs"], "peak_memory_mb", 0.0)
         finished = engine_outputs.finished
 
+        # Propagate entropy guardrail stop_reason across stages.
+        # Stage-0 (AR talker) sets stop_reason="entropy_guardrail:..." on its
+        # output, but only the final stage's output reaches the serving layer.
+        # Store it on the metrics aggregator so the final stage can inherit it.
+        _GUARDRAIL_PREFIX = "entropy_guardrail:"
+        for _out in getattr(engine_outputs, "outputs", []):
+            sr = getattr(_out, "stop_reason", None)
+            if isinstance(sr, str) and sr.startswith(_GUARDRAIL_PREFIX):
+                metrics._guardrail_stop_reason = sr
+                break
+
         submit_ts = result.get("stage_submit_ts")
         now = time.time()
         if metrics.stage_first_ts[stage_id] is None:
@@ -276,7 +287,7 @@ class OmniBase:
             logger.exception("[%s] Finalize request handling error", self.__class__.__name__)
 
         images = getattr(engine_outputs, "images", []) if stage_meta["final_output_type"] == "image" else []
-        return OmniRequestOutput(
+        omni_output = OmniRequestOutput(
             request_id=req_id or "",
             stage_id=stage_id,
             final_output_type=stage_meta["final_output_type"],
@@ -285,6 +296,19 @@ class OmniBase:
             stage_durations=stage_durations,
             peak_memory_mb=peak_memory_mb,
         )
+
+        # Inject guardrail stop_reason from earlier stage into final output.
+        # Always prefer guardrail string over plain integer EOS token ID,
+        # since the guardrail is why the request actually stopped.
+        guardrail_sr = getattr(metrics, "_guardrail_stop_reason", None)
+        if guardrail_sr and omni_output is not None:
+            ro = getattr(omni_output, "request_output", None)
+            for _out in getattr(ro, "outputs", []):
+                existing = getattr(_out, "stop_reason", None)
+                if existing is None or isinstance(existing, int):
+                    _out.stop_reason = guardrail_sr
+
+        return omni_output
 
     def shutdown(self) -> None:
         logger.info("[%s] Shutting down", self.__class__.__name__)

--- a/vllm_omni/entrypoints/openai/api_server.py
+++ b/vllm_omni/entrypoints/openai/api_server.py
@@ -69,9 +69,12 @@ from vllm.entrypoints.pooling.pooling.serving import OpenAIServingPooling
 from vllm.entrypoints.pooling.score.serving import ServingScores
 from vllm.entrypoints.serve.disagg.serving import ServingTokens
 
-# vLLM moved `base` from openai.basic.api_router to serve.instrumentator.basic.
-# Keep a fallback for older/newer upstream layouts during rebase windows.
-from vllm.entrypoints.serve.instrumentator.basic import base
+# vLLM moved `base` from openai.basic.api_router to serve.instrumentator.basic
+# (available in >=0.18). Keep a fallback for 0.16.x layouts.
+try:
+    from vllm.entrypoints.serve.instrumentator.basic import base
+except (ImportError, ModuleNotFoundError):
+    from vllm.entrypoints.openai.api_server import base
 from vllm.entrypoints.serve.render.serving import OpenAIServingRender
 from vllm.entrypoints.serve.tokenize.serving import OpenAIServingTokenization
 from vllm.entrypoints.utils import (

--- a/vllm_omni/entrypoints/openai/protocol/audio.py
+++ b/vllm_omni/entrypoints/openai/protocol/audio.py
@@ -61,10 +61,6 @@ class OpenAICreateSpeechRequest(BaseModel):
         "2048-dim for 1.7B). Skips speaker encoder extraction from ref_audio. "
         "Implies x_vector_only_mode=True. Mutually exclusive with ref_audio.",
     )
-    stream: bool = Field(
-        default=False,
-        description="Stream audio chunks progressively as they are generated.",
-    )
     max_new_tokens: int | None = Field(
         default=None,
         description="Maximum tokens to generate",

--- a/vllm_omni/entrypoints/openai/protocol/audio.py
+++ b/vllm_omni/entrypoints/openai/protocol/audio.py
@@ -75,6 +75,28 @@ class OpenAICreateSpeechRequest(BaseModel):
         description="Per-request initial chunk size override. If null, computed dynamically based on server load.",
     )
 
+    # Entropy guardrail parameters
+    entropy_guardrail: bool | None = Field(
+        default=None,
+        description="Enable entropy-based degeneration detection. When triggered, "
+        "generation stops early to prevent noise output. Default: server config.",
+    )
+    entropy_threshold_high: float | None = Field(
+        default=None,
+        ge=0.0,
+        description="Upper entropy threshold (nats). Consecutive steps above this trigger halt. Default: 4.5.",
+    )
+    entropy_threshold_low: float | None = Field(
+        default=None,
+        ge=0.0,
+        description="Lower entropy threshold (nats). Consecutive steps below this trigger halt. Default: 0.5.",
+    )
+    entropy_window: int | None = Field(
+        default=None,
+        ge=1,
+        description="Number of consecutive out-of-range steps before triggering. Default: 5.",
+    )
+
     @field_validator("stream_format")
     @classmethod
     def validate_stream_format(cls, v: str) -> str:

--- a/vllm_omni/entrypoints/openai/serving_speech.py
+++ b/vllm_omni/entrypoints/openai/serving_speech.py
@@ -67,6 +67,44 @@ _TTS_MAX_INSTRUCTIONS_LENGTH = 500
 _TTS_MAX_NEW_TOKENS_MIN = 1
 _TTS_MAX_NEW_TOKENS_MAX = 4096
 
+# Sentinel trailer for entropy guardrail signaling.
+# 8 zero bytes (4 silent PCM samples at 16-bit, inaudible) + ASCII magic.
+_GUARDRAIL_SENTINEL = b"\x00" * 8 + b"VLLMMETA"
+
+
+_GUARDRAIL_STOP_PREFIX = "entropy_guardrail:"
+
+
+def _extract_stop_reason_guardrail(res) -> str | None:
+    """Extract entropy guardrail JSON from stop_reason on any OmniRequestOutput."""
+    if res is None:
+        return None
+    # Walk request_output.outputs[] to find stop_reason
+    ro = getattr(res, "request_output", None) or res
+    for output in getattr(ro, "outputs", []):
+        sr = getattr(output, "stop_reason", None)
+        if isinstance(sr, str) and sr.startswith(_GUARDRAIL_STOP_PREFIX):
+            return sr[len(_GUARDRAIL_STOP_PREFIX) :]
+    # Also check top-level stop_reason
+    sr = getattr(ro, "stop_reason", None)
+    if isinstance(sr, str) and sr.startswith(_GUARDRAIL_STOP_PREFIX):
+        return sr[len(_GUARDRAIL_STOP_PREFIX) :]
+    return None
+
+
+def _build_guardrail_trailer_from_stop_reason(res) -> bytes | None:
+    """Build a sentinel trailer from stop_reason if the guardrail triggered.
+
+    Format: [8 zero bytes][VLLMMETA][4-byte LE uint32 length][UTF-8 JSON]
+    Returns None if the guardrail did not trigger.
+    """
+    payload_str = _extract_stop_reason_guardrail(res)
+    if payload_str is None:
+        return None
+    payload = payload_str.encode("utf-8")
+    length = struct.pack("<I", len(payload))
+    return _GUARDRAIL_SENTINEL + length + payload
+
 
 def _create_wav_header(sample_rate: int, num_channels: int = 1, bits_per_sample: int = 16) -> bytes:
     """Create a WAV header with placeholder size values for streaming.
@@ -914,6 +952,10 @@ class OmniOpenAIServingSpeech(OpenAIServing, AudioMixin):
         - Per-step mode (tensor): Engine returns single tensor per iteration;
         we emit it directly.
 
+        If the entropy guardrail triggered during generation, a sentinel
+        trailer frame is appended after the last audio chunk so clients
+        can detect the forced termination.
+
         Args:
             generator: Async generator from the engine
             request_id: Request identifier for logging
@@ -925,9 +967,11 @@ class OmniOpenAIServingSpeech(OpenAIServing, AudioMixin):
         prev_count = 0
         sample_rate_val = 24000
         first_chunk = True
+        last_res = None
 
         try:
             async for res in generator:
+                last_res = res
                 audio_output, audio_key = self._extract_audio_output(res)
                 if audio_key is None:
                     continue
@@ -977,6 +1021,15 @@ class OmniOpenAIServingSpeech(OpenAIServing, AudioMixin):
                         base64_encode=False,
                     )
                     yield self.create_audio(audio_obj).audio_data
+
+            # After all audio chunks, check for entropy guardrail sentinel.
+            # The guardrail metadata is encoded in stop_reason (set by the
+            # scheduler from the AR model runner's pooler_output) because it
+            # survives IPC serialization, unlike custom keys in pooler_output.
+            trailer = _build_guardrail_trailer_from_stop_reason(last_res)
+            if trailer is not None:
+                logger.info("Appending entropy guardrail trailer for request %s", request_id)
+                yield trailer
         except asyncio.CancelledError:
             logger.info("Streaming request %s cancelled by client", request_id)
             raise
@@ -1391,40 +1444,7 @@ class OmniOpenAIServingSpeech(OpenAIServing, AudioMixin):
             return error_check_ret
 
         try:
-            if self._is_tts:
-                # Validate TTS parameters
-                validation_error = self._validate_tts_request(request)
-                if validation_error:
-                    return self.create_error_response(validation_error)
-
-                tts_params = self._build_tts_params(request)
-                if request.ref_audio is not None:
-                    wav_list, sr = await self._resolve_ref_audio(request.ref_audio)
-                    tts_params["ref_audio"] = [[wav_list, sr]]
-
-                # Prompt length must match model-side embeddings; values are placeholders.
-                ph_len = self._estimate_prompt_len(tts_params)
-                prompt = {"prompt_token_ids": [1] * ph_len, "additional_information": tts_params}
-            else:
-                tts_params = {}
-                prompt = {"prompt": request.input}
-
-            logger.info(
-                "TTS speech request %s: text=%r, task_type=%s, stream=%s",
-                request_id,
-                request.input[:50] + "..." if len(request.input) > 50 else request.input,
-                tts_params.get("task_type", ["unknown"])[0],
-                request.stream,
-            )
-
-            sampling_params_list = self.engine_client.default_sampling_params_list
-
-            generator = self.engine_client.generate(
-                prompt=prompt,
-                request_id=request_id,
-                sampling_params_list=sampling_params_list,
-                output_modalities=["audio"],
-            )
+            request_id, generator, tts_params = await self._prepare_speech_generation(request)
 
             if request.stream:
                 # Determine response format and media type for streaming
@@ -1445,10 +1465,13 @@ class OmniOpenAIServingSpeech(OpenAIServing, AudioMixin):
                     )
 
                 media_type = "audio/wav" if response_format == "wav" else "audio/pcm"
-                request_id, generator, _ = await self._prepare_speech_generation(request)
+                headers = {}
+                if request.entropy_guardrail:
+                    headers["X-TTS-Trailer"] = "supported"
                 return StreamingResponse(
                     self._generate_audio_chunks(generator, request_id, response_format),
                     media_type=media_type,
+                    headers=headers or None,
                 )
 
             # Non-streaming: collect final output
@@ -1462,6 +1485,10 @@ class OmniOpenAIServingSpeech(OpenAIServing, AudioMixin):
             audio_output, audio_key = self._extract_audio_output(final_output)
             if audio_key is None:
                 return self.create_error_response("TTS model did not produce audio output.")
+
+            # Check for entropy guardrail trigger via stop_reason.
+            guardrail_json = _extract_stop_reason_guardrail(final_output)
+            guardrail_header = {"X-TTS-Guardrail": guardrail_json} if guardrail_json else {}
 
             audio_tensor = audio_output[audio_key]
             sr_raw = audio_output.get("sr", 24000)
@@ -1488,7 +1515,11 @@ class OmniOpenAIServingSpeech(OpenAIServing, AudioMixin):
                     base64_encode=False,
                 )
                 audio_response: AudioResponse = self.create_audio(audio_obj)
-                return Response(content=audio_response.audio_data, media_type=audio_response.media_type)
+                return Response(
+                    content=audio_response.audio_data,
+                    media_type=audio_response.media_type,
+                    headers=guardrail_header,
+                )
 
             audio_obj = CreateAudio(
                 audio_tensor=audio_tensor,
@@ -1499,7 +1530,11 @@ class OmniOpenAIServingSpeech(OpenAIServing, AudioMixin):
                 base64_encode=False,
             )
             audio_response = self.create_audio(audio_obj)
-            return Response(content=audio_response.audio_data, media_type=audio_response.media_type)
+            return Response(
+                content=audio_response.audio_data,
+                media_type=audio_response.media_type,
+                headers=guardrail_header,
+            )
 
         except asyncio.CancelledError:
             return self.create_error_response("Client disconnected")

--- a/vllm_omni/entrypoints/openai/serving_speech.py
+++ b/vllm_omni/entrypoints/openai/serving_speech.py
@@ -1105,6 +1105,16 @@ class OmniOpenAIServingSpeech(OpenAIServing, AudioMixin):
         if request.initial_codec_chunk_frames is not None:
             params["initial_codec_chunk_frames"] = [request.initial_codec_chunk_frames]
 
+        # Entropy guardrail parameters
+        if request.entropy_guardrail is not None:
+            params["entropy_guardrail"] = [request.entropy_guardrail]
+        if request.entropy_threshold_high is not None:
+            params["entropy_threshold_high"] = [request.entropy_threshold_high]
+        if request.entropy_threshold_low is not None:
+            params["entropy_threshold_low"] = [request.entropy_threshold_low]
+        if request.entropy_window is not None:
+            params["entropy_window"] = [request.entropy_window]
+
         # VoiceDesign requires non_streaming_mode (match offline script behaviour).
         # CustomVoice and Base rely on the model default (True and False respectively).
         if params["task_type"][0] == "VoiceDesign":

--- a/vllm_omni/model_executor/models/qwen3_tts/qwen3_tts_code2wav.py
+++ b/vllm_omni/model_executor/models/qwen3_tts/qwen3_tts_code2wav.py
@@ -214,6 +214,7 @@ class Qwen3TTSCode2Wav(nn.Module):
         valid_codes_qf: list[torch.Tensor] = []
         valid_indices: list[int] = []
         left_context_size = [0] * len(request_ids_list)
+        guardrail_triggers: list[dict[str, Any] | None] = [None] * len(request_ids_list)
         if runtime_additional_information is not None:
             for i, info in enumerate(runtime_additional_information):
                 if i >= len(left_context_size):
@@ -226,6 +227,10 @@ class Qwen3TTSCode2Wav(nn.Module):
                     if isinstance(value, torch.Tensor):
                         value = value.reshape(-1)[0].item() if value.numel() > 0 else 0
                     left_context_size[i] = int(value)
+                # Pass through entropy guardrail trigger metadata.
+                gt = info.get("entropy_guardrail_triggered")
+                if gt is not None and i < len(guardrail_triggers):
+                    guardrail_triggers[i] = gt
         for i, req_ids in enumerate(request_ids_list):
             if req_ids.numel() < 1:
                 parsed.append((0, 0))
@@ -307,10 +312,23 @@ class Qwen3TTSCode2Wav(nn.Module):
             if wav.shape[0] > 0:
                 audios[idx] = wav.to(dtype=torch.float32).reshape(-1)
 
-        return OmniOutput(
-            text_hidden_states=None,
-            multimodal_outputs={"model_outputs": audios, "sr": srs},
-        )
+        mm: dict[str, Any] = {"model_outputs": audios, "sr": srs}
+        # Include entropy guardrail trigger metadata as a JSON-encoded
+        # byte tensor per request.  Encoding as tensors is required because
+        # the generation model runner only handles tensor values in the
+        # multimodal output dict (non-tensors are dropped with a warning).
+        if any(g is not None for g in guardrail_triggers):
+            import json as _json
+
+            encoded: list[torch.Tensor] = []
+            for g in guardrail_triggers:
+                if g is not None:
+                    raw = _json.dumps(g).encode("utf-8")
+                    encoded.append(torch.frombuffer(bytearray(raw), dtype=torch.uint8))
+                else:
+                    encoded.append(torch.zeros(0, dtype=torch.uint8))
+            mm["entropy_guardrail_triggered"] = encoded
+        return OmniOutput(text_hidden_states=None, multimodal_outputs=mm)
 
     def make_omni_output(self, model_outputs: torch.Tensor | OmniOutput, **kwargs: Any) -> OmniOutput:
         if isinstance(model_outputs, OmniOutput):

--- a/vllm_omni/model_executor/models/qwen3_tts/qwen3_tts_talker.py
+++ b/vllm_omni/model_executor/models/qwen3_tts/qwen3_tts_talker.py
@@ -330,15 +330,18 @@ class Qwen3TTSTalkerForConditionalGeneration(nn.Module):
         self._eos_logit_bias: float = 0.0
 
         # Entropy guardrail: per-request state keyed by id(output_token_ids list).
-        # Each entry: {"consecutive_oob": int, "config": dict}
+        # Each entry: {"consecutive_oob": int, "cfg": dict}
         self._entropy_state: dict[int, dict[str, Any]] = {}
-        # Default guardrail config (can be overridden per-request via additional_information).
+        # Default guardrail config (used when no per-request override is provided).
         self._entropy_defaults: dict[str, Any] = {
             "enabled": False,
             "threshold_high": 4.5,
             "threshold_low": 0.5,
             "window": 5,
         }
+        # Staging queue: preprocess appends per-request entropy configs in batch
+        # order; _apply_entropy_guardrail consumes them to initialize new entries.
+        self._entropy_config_staging: list[dict[str, Any]] = []
 
         self.have_multimodal_outputs = True
         self.has_preprocess = True
@@ -466,11 +469,10 @@ class Qwen3TTSTalkerForConditionalGeneration(nn.Module):
         When consecutive out-of-range steps exceed the window size, the EOS token
         logit is set very high and all others suppressed, forcing the sampler to
         pick EOS and terminate generation cleanly.
-        """
-        cfg = self._entropy_defaults
-        if not cfg["enabled"]:
-            return logits
 
+        Per-request config is stored in ``_entropy_state[key]["cfg"]`` and
+        initialized from ``_entropy_config_staging`` (populated by preprocess).
+        """
         output_token_ids = getattr(sampling_metadata, "output_token_ids", None)
         if not output_token_ids:
             return logits
@@ -479,58 +481,97 @@ class Qwen3TTSTalkerForConditionalGeneration(nn.Module):
         if eos_id < 0 or eos_id >= logits.shape[-1]:
             return logits
 
-        threshold_high = cfg["threshold_high"]
-        threshold_low = cfg["threshold_low"]
-        window = cfg["window"]
+        batch_size = min(logits.shape[0], len(output_token_ids))
+
+        # Consume staged configs (from preprocess) for new requests.
+        staged = self._entropy_config_staging
+        self._entropy_config_staging = []
+
+        # Check if any request in the batch has the guardrail enabled.
+        any_enabled = False
+        for i in range(batch_size):
+            key = id(output_token_ids[i])
+            state = self._entropy_state.get(key)
+            if state is not None:
+                if state["cfg"]["enabled"]:
+                    any_enabled = True
+            elif staged:
+                # New request: pop first staged config.
+                cfg = staged.pop(0)
+                if cfg["enabled"]:
+                    any_enabled = True
+                self._entropy_state[key] = {
+                    "consecutive_oob": 0,
+                    "last_step": 0,
+                    "cfg": cfg,
+                }
+            else:
+                # No staged config available; use defaults.
+                if self._entropy_defaults["enabled"]:
+                    any_enabled = True
+                self._entropy_state[key] = {
+                    "consecutive_oob": 0,
+                    "last_step": 0,
+                    "cfg": dict(self._entropy_defaults),
+                }
+
+        if not any_enabled:
+            return logits
 
         # Compute entropy for each batch element.
-        # Use only the valid (non -inf) logits for stable softmax.
         with torch.no_grad():
             probs = F.softmax(logits, dim=-1)
-            # Shannon entropy in nats: H = -sum(p * ln(p))
             log_probs = torch.log(probs + 1e-10)
             entropy = -torch.sum(probs * log_probs, dim=-1)  # shape: (batch,)
 
-        batch_size = min(logits.shape[0], len(output_token_ids))
         for i in range(batch_size):
-            tok_list = output_token_ids[i]
-            key = id(tok_list)
-            step = len(tok_list)
+            key = id(output_token_ids[i])
+            state = self._entropy_state.get(key)
+            if state is None:
+                continue
 
-            # Skip prefill steps (no meaningful entropy yet).
+            cfg = state["cfg"]
+            if not cfg["enabled"]:
+                continue
+
+            step = len(output_token_ids[i])
+            # Skip early steps (no meaningful entropy yet).
             if step < 2:
                 continue
 
             h = float(entropy[i].item())
 
-            state = self._entropy_state.get(key)
-            if state is None:
-                state = {"consecutive_oob": 0, "last_step": step}
-                self._entropy_state[key] = state
+            if step % 100 == 0:
+                logger.debug(
+                    "Entropy monitor: step=%d, entropy=%.3f, consecutive_oob=%d",
+                    step,
+                    h,
+                    state["consecutive_oob"],
+                )
 
-            # Check if entropy is out of bounds.
-            out_of_bounds = h > threshold_high or h < threshold_low
+            out_of_bounds = h > cfg["threshold_high"] or h < cfg["threshold_low"]
             if out_of_bounds:
                 state["consecutive_oob"] += 1
             else:
                 state["consecutive_oob"] = 0
             state["last_step"] = step
 
-            # Trigger: force EOS.
-            if state["consecutive_oob"] >= window:
+            if state["consecutive_oob"] >= cfg["window"]:
                 logger.warning(
                     "Entropy guardrail triggered at step %d (entropy=%.3f, "
                     "consecutive_oob=%d, thresholds=[%.2f, %.2f]). Forcing EOS.",
                     step,
                     h,
                     state["consecutive_oob"],
-                    threshold_low,
-                    threshold_high,
+                    cfg["threshold_low"],
+                    cfg["threshold_high"],
                 )
                 logits[i, :] = float("-inf")
                 logits[i, eos_id] = 100.0
+                # Reset counter so we don't log on every subsequent step.
+                state["consecutive_oob"] = 0
 
-        # Prune stale entries (requests that finished without cleanup).
+        # Prune stale entries (requests that finished).
         if len(self._entropy_state) > batch_size * 2 + 10:
             active_keys = {id(output_token_ids[i]) for i in range(batch_size)}
             stale = [k for k in self._entropy_state if k not in active_keys]
@@ -606,23 +647,31 @@ class Qwen3TTSTalkerForConditionalGeneration(nn.Module):
     # -------------------- entropy guardrail config --------------------
 
     def _update_entropy_config_from_info(self, info_dict: dict[str, Any]) -> None:
-        """Update entropy guardrail defaults from per-request additional_information."""
+        """Stage per-request entropy guardrail config for consumption by compute_logits.
+
+        Builds a config dict from per-request additional_information, falling back
+        to model-level defaults for any unset parameters. The config is appended to
+        ``_entropy_config_staging`` and consumed in batch order by
+        ``_apply_entropy_guardrail`` when initializing new per-request state.
+        """
 
         def _first(val: Any) -> Any:
             return val[0] if isinstance(val, list) and val else val
 
+        cfg = dict(self._entropy_defaults)  # copy defaults
         eg = _first(info_dict.get("entropy_guardrail"))
         if eg is not None:
-            self._entropy_defaults["enabled"] = bool(eg)
+            cfg["enabled"] = bool(eg)
         eth = _first(info_dict.get("entropy_threshold_high"))
         if eth is not None:
-            self._entropy_defaults["threshold_high"] = float(eth)
+            cfg["threshold_high"] = float(eth)
         etl = _first(info_dict.get("entropy_threshold_low"))
         if etl is not None:
-            self._entropy_defaults["threshold_low"] = float(etl)
+            cfg["threshold_low"] = float(etl)
         ew = _first(info_dict.get("entropy_window"))
         if ew is not None:
-            self._entropy_defaults["window"] = int(ew)
+            cfg["window"] = int(ew)
+        self._entropy_config_staging.append(cfg)
 
     # -------------------- preprocess / postprocess --------------------
 

--- a/vllm_omni/model_executor/models/qwen3_tts/qwen3_tts_talker.py
+++ b/vllm_omni/model_executor/models/qwen3_tts/qwen3_tts_talker.py
@@ -329,6 +329,17 @@ class Qwen3TTSTalkerForConditionalGeneration(nn.Module):
 
         self._eos_logit_bias: float = 0.0
 
+        # Entropy guardrail: per-request state keyed by id(output_token_ids list).
+        # Each entry: {"consecutive_oob": int, "config": dict}
+        self._entropy_state: dict[int, dict[str, Any]] = {}
+        # Default guardrail config (can be overridden per-request via additional_information).
+        self._entropy_defaults: dict[str, Any] = {
+            "enabled": False,
+            "threshold_high": 4.5,
+            "threshold_low": 0.5,
+            "window": 5,
+        }
+
         self.have_multimodal_outputs = True
         self.has_preprocess = True
         self.has_postprocess = True
@@ -440,6 +451,92 @@ class Qwen3TTSTalkerForConditionalGeneration(nn.Module):
             if 0 <= eos_id < logits.shape[-1]:
                 logits[:, eos_id] = logits[:, eos_id] + self._eos_logit_bias
 
+        # Entropy guardrail: detect degeneration and force EOS.
+        logits = self._apply_entropy_guardrail(logits, sampling_metadata)
+
+        return logits
+
+    def _apply_entropy_guardrail(self, logits: torch.Tensor, sampling_metadata: Any) -> torch.Tensor:
+        """Monitor per-request entropy and force EOS when degeneration is detected.
+
+        Degeneration is signaled by entropy consistently leaving a healthy range:
+        - Spike (above threshold_high): model is lost/uncertain
+        - Collapse (below threshold_low): model is stuck in a loop
+
+        When consecutive out-of-range steps exceed the window size, the EOS token
+        logit is set very high and all others suppressed, forcing the sampler to
+        pick EOS and terminate generation cleanly.
+        """
+        cfg = self._entropy_defaults
+        if not cfg["enabled"]:
+            return logits
+
+        output_token_ids = getattr(sampling_metadata, "output_token_ids", None)
+        if not output_token_ids:
+            return logits
+
+        eos_id = self._codec_eos_token_id
+        if eos_id < 0 or eos_id >= logits.shape[-1]:
+            return logits
+
+        threshold_high = cfg["threshold_high"]
+        threshold_low = cfg["threshold_low"]
+        window = cfg["window"]
+
+        # Compute entropy for each batch element.
+        # Use only the valid (non -inf) logits for stable softmax.
+        with torch.no_grad():
+            probs = F.softmax(logits, dim=-1)
+            # Shannon entropy in nats: H = -sum(p * ln(p))
+            log_probs = torch.log(probs + 1e-10)
+            entropy = -torch.sum(probs * log_probs, dim=-1)  # shape: (batch,)
+
+        batch_size = min(logits.shape[0], len(output_token_ids))
+        for i in range(batch_size):
+            tok_list = output_token_ids[i]
+            key = id(tok_list)
+            step = len(tok_list)
+
+            # Skip prefill steps (no meaningful entropy yet).
+            if step < 2:
+                continue
+
+            h = float(entropy[i].item())
+
+            state = self._entropy_state.get(key)
+            if state is None:
+                state = {"consecutive_oob": 0, "last_step": step}
+                self._entropy_state[key] = state
+
+            # Check if entropy is out of bounds.
+            out_of_bounds = h > threshold_high or h < threshold_low
+            if out_of_bounds:
+                state["consecutive_oob"] += 1
+            else:
+                state["consecutive_oob"] = 0
+            state["last_step"] = step
+
+            # Trigger: force EOS.
+            if state["consecutive_oob"] >= window:
+                logger.warning(
+                    "Entropy guardrail triggered at step %d (entropy=%.3f, "
+                    "consecutive_oob=%d, thresholds=[%.2f, %.2f]). Forcing EOS.",
+                    step,
+                    h,
+                    state["consecutive_oob"],
+                    threshold_low,
+                    threshold_high,
+                )
+                logits[i, :] = float("-inf")
+                logits[i, eos_id] = 100.0
+
+        # Prune stale entries (requests that finished without cleanup).
+        if len(self._entropy_state) > batch_size * 2 + 10:
+            active_keys = {id(output_token_ids[i]) for i in range(batch_size)}
+            stale = [k for k in self._entropy_state if k not in active_keys]
+            for k in stale:
+                del self._entropy_state[k]
+
         return logits
 
     # -------------------- Omni multimodal output plumbing --------------------
@@ -506,6 +603,27 @@ class Qwen3TTSTalkerForConditionalGeneration(nn.Module):
             mm["codec_streaming"] = torch.cat(codec_streaming_list, dim=0)[:span_len]
         return OmniOutput(text_hidden_states=hidden, multimodal_outputs=mm)
 
+    # -------------------- entropy guardrail config --------------------
+
+    def _update_entropy_config_from_info(self, info_dict: dict[str, Any]) -> None:
+        """Update entropy guardrail defaults from per-request additional_information."""
+
+        def _first(val: Any) -> Any:
+            return val[0] if isinstance(val, list) and val else val
+
+        eg = _first(info_dict.get("entropy_guardrail"))
+        if eg is not None:
+            self._entropy_defaults["enabled"] = bool(eg)
+        eth = _first(info_dict.get("entropy_threshold_high"))
+        if eth is not None:
+            self._entropy_defaults["threshold_high"] = float(eth)
+        etl = _first(info_dict.get("entropy_threshold_low"))
+        if etl is not None:
+            self._entropy_defaults["threshold_low"] = float(etl)
+        ew = _first(info_dict.get("entropy_window"))
+        if ew is not None:
+            self._entropy_defaults["window"] = int(ew)
+
     # -------------------- preprocess / postprocess --------------------
 
     def preprocess(
@@ -521,6 +639,9 @@ class Qwen3TTSTalkerForConditionalGeneration(nn.Module):
             for k, v in additional_information.items():
                 merged.setdefault(k, v)
             info_dict = merged
+
+        # Update entropy guardrail config from per-request additional_information.
+        self._update_entropy_config_from_info(info_dict)
 
         span_len = int(input_ids.shape[0])
         if span_len <= 0:

--- a/vllm_omni/model_executor/models/qwen3_tts/qwen3_tts_talker.py
+++ b/vllm_omni/model_executor/models/qwen3_tts/qwen3_tts_talker.py
@@ -342,6 +342,10 @@ class Qwen3TTSTalkerForConditionalGeneration(nn.Module):
         # Staging queue: preprocess appends per-request entropy configs in batch
         # order; _apply_entropy_guardrail consumes them to initialize new entries.
         self._entropy_config_staging: list[dict[str, Any]] = []
+        # Per-request guardrail trigger metadata, keyed by batch index.
+        # Set by _apply_entropy_guardrail, consumed by the AR model runner
+        # (gpu_ar_model_runner.py) which injects it into pooler_output.
+        self._entropy_guardrail_triggered: dict[int, dict[str, Any]] = {}
 
         self.have_multimodal_outputs = True
         self.has_preprocess = True
@@ -473,6 +477,9 @@ class Qwen3TTSTalkerForConditionalGeneration(nn.Module):
         Per-request config is stored in ``_entropy_state[key]["cfg"]`` and
         initialized from ``_entropy_config_staging`` (populated by preprocess).
         """
+        # Reset per-step guardrail trigger state.
+        self._entropy_guardrail_triggered.clear()
+
         output_token_ids = getattr(sampling_metadata, "output_token_ids", None)
         if not output_token_ids:
             return logits
@@ -492,6 +499,12 @@ class Qwen3TTSTalkerForConditionalGeneration(nn.Module):
         for i in range(batch_size):
             key = id(output_token_ids[i])
             state = self._entropy_state.get(key)
+            if state is not None:
+                # Guard against id() reuse: if the token count is less than
+                # what we previously tracked, the address was recycled.
+                if len(output_token_ids[i]) < state["last_step"]:
+                    del self._entropy_state[key]
+                    state = None
             if state is not None:
                 if state["cfg"]["enabled"]:
                     any_enabled = True
@@ -520,8 +533,8 @@ class Qwen3TTSTalkerForConditionalGeneration(nn.Module):
 
         # Compute entropy for each batch element.
         with torch.no_grad():
-            probs = F.softmax(logits, dim=-1)
-            log_probs = torch.log(probs + 1e-10)
+            log_probs = F.log_softmax(logits, dim=-1)
+            probs = log_probs.exp()
             entropy = -torch.sum(probs * log_probs, dim=-1)  # shape: (batch,)
 
         for i in range(batch_size):
@@ -568,6 +581,15 @@ class Qwen3TTSTalkerForConditionalGeneration(nn.Module):
                 )
                 logits[i, :] = float("-inf")
                 logits[i, eos_id] = 100.0
+                # Store trigger metadata for the serving layer (keyed by batch index).
+                reason = "low_entropy" if h < cfg["threshold_low"] else "high_entropy"
+                self._entropy_guardrail_triggered[i] = {
+                    "step": step,
+                    "entropy": round(h, 4),
+                    "reason": reason,
+                    "threshold": cfg["threshold_low"] if reason == "low_entropy" else cfg["threshold_high"],
+                    "window": cfg["window"],
+                }
                 # Reset counter so we don't log on every subsequent step.
                 state["consecutive_oob"] = 0
 
@@ -816,13 +838,13 @@ class Qwen3TTSTalkerForConditionalGeneration(nn.Module):
         }
         return input_ids, inputs_embeds_out, info_update
 
-    def postprocess(self, hidden_states: torch.Tensor, **_: Any) -> dict[str, Any]:
+    def postprocess(self, hidden_states: torch.Tensor, **kwargs: Any) -> dict[str, Any]:
         # Keep the last token hidden for the next decode step's code predictor.
         # Stays on GPU - gpu_resident_buffer_keys avoids the CPU round-trip.
         if hidden_states.numel() == 0:
             return {}
-        last = hidden_states[-1, :].detach()
-        return {"last_talker_hidden": last}
+        result: dict[str, Any] = {"last_talker_hidden": hidden_states[-1, :].detach()}
+        return result
 
     # -------------------- prompt construction helpers --------------------
 

--- a/vllm_omni/worker/gpu_ar_model_runner.py
+++ b/vllm_omni/worker/gpu_ar_model_runner.py
@@ -6,6 +6,7 @@ and also outputs sampled tokens.
 
 from __future__ import annotations
 
+import json as _json
 from copy import copy
 from typing import Any, NamedTuple
 
@@ -617,6 +618,20 @@ class GPUARModelRunner(OmniGPUModelRunner):
                         mm_payload[k] = v
                 payload.update(mm_payload)
             pooler_output.append(payload)
+
+        # Inject entropy guardrail trigger metadata into pooler_output.
+        # The talker stores trigger info keyed by batch index in
+        # _entropy_guardrail_triggered during compute_logits.  We encode
+        # it as a JSON byte tensor so it survives the output pipeline.
+        guardrail_triggered = getattr(self.model, "_entropy_guardrail_triggered", None)
+        if guardrail_triggered:
+            for batch_idx, trigger_meta in guardrail_triggered.items():
+                if batch_idx < len(pooler_output):
+                    raw = _json.dumps(trigger_meta).encode("utf-8")
+                    pooler_output[batch_idx]["entropy_guardrail_triggered"] = torch.frombuffer(
+                        bytearray(raw), dtype=torch.uint8
+                    )
+
         with record_function_or_nullcontext("gpu_model_runner: ModelRunnerOutput"):
             if self.routed_experts_initialized:
                 capturer = RoutedExpertsCapturer.get_instance()


### PR DESCRIPTION
## Summary

- **Entropy-based degeneration guardrail** for Qwen3-TTS AR talker: monitors per-token entropy during generation and forces EOS when consecutive out-of-bounds steps exceed a configurable window
- **Sentinel trailer** appended to streaming PCM responses when the guardrail fires, allowing HTTP clients to detect forced termination
- **Non-streaming** responses get an `X-TTS-Guardrail` response header instead

### Entropy Guardrail

Monitors two degeneration modes during AR codec generation:
- **High entropy** (model lost/uncertain): entropy exceeds `threshold_high` for N consecutive steps
- **Low entropy** (stuck in loop): entropy drops below `threshold_low` for N consecutive steps

API parameters: `entropy_guardrail`, `entropy_threshold_high`, `entropy_threshold_low`, `entropy_window`

### Sentinel Trailer Design

When the guardrail triggers during streaming, a trailer is appended after the last PCM chunk:

```
[8 zero bytes (inaudible silence)] [VLLMMETA] [4-byte LE uint32 length] [UTF-8 JSON]
```

JSON payload example: `{"step": 6, "entropy": 0.254, "reason": "low_entropy", "threshold": 0.5, "window": 5}`

Backwards compatible: old clients play through the sentinel with no perceptible artifact.

### Signal Path Through Multi-Stage Pipeline

1. **Talker** `compute_logits` → `_entropy_guardrail_triggered` dict
2. **AR model runner** `sample_tokens` → JSON byte tensor in `pooler_output`
3. **Omni AR scheduler** → extracts from `pooler_output`, sets `request.stop_reason` AFTER `check_stop`
4. **Orchestrator** `_process_single_result` → captures from Stage-0, stashes on metrics
5. **Orchestrator** final stage → injects into `CompletionOutput.stop_reason`
6. **Serving layer** → reads `stop_reason`, builds sentinel trailer

### Files Changed

| File | Change |
|------|--------|
| `qwen3_tts_talker.py` | Guardrail logic + trigger metadata + id() staleness check |
| `protocol/audio.py` | API parameters |
| `serving_speech.py` | Sentinel trailer, headers, stop_reason extraction |
| `gpu_ar_model_runner.py` | Inject metadata into pooler_output |
| `omni_ar_scheduler.py` | Extract metadata to stop_reason |
| `omni_base.py` | Relay stop_reason across stages |

## Test plan

- [x] 18 unit tests pass
- [x] E2E validated on rogue deployment (0.6B-Base model)
- [x] Sentinel trailer parsed correctly by client
- [x] Normal completion produces no sentinel (no false positives)
- [x] Non-streaming path returns `X-TTS-Guardrail` header
- [x] Review fixes: id() staleness, F.log_softmax, non-streaming signal drop

🤖 Generated with [Claude Code](https://claude.com/claude-code)