### PR TITLE
ci: import gate before image push

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -48,13 +48,36 @@ jobs:
             type=semver,pattern={{major}}.{{minor}}
             type=sha,prefix=
 
-      - name: Build and push (CUDA)
+      - name: Build (CUDA, load locally for import gate)
         uses: docker/build-push-action@v6
         with:
           context: .
           file: docker/Dockerfile.slim
-          push: true
+          load: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+      - name: Import gate
+        # Boots the CLI entrypoint with --help; fails the workflow on any
+        # ImportError before the image reaches the registry. Caught the
+        # vllm-0.20-path-validation class of regression in the 2026-05-12 rebase.
+        env:
+          TAGS: ${{ steps.meta.outputs.tags }}
+        run: |
+          set -euo pipefail
+          FIRST_TAG=$(printf '%s\n' "$TAGS" | head -n1)
+          echo "Running import gate against $FIRST_TAG"
+          docker run --rm --entrypoint python "$FIRST_TAG" \
+            -m vllm_omni.entrypoints.cli.main serve --help >/dev/null
+
+      - name: Push (CUDA)
+        env:
+          TAGS: ${{ steps.meta.outputs.tags }}
+        run: |
+          set -euo pipefail
+          while IFS= read -r tag; do
+            [ -n "$tag" ] || continue
+            docker push "$tag"
+          done <<<"$TAGS"


### PR DESCRIPTION
## Summary
- Adds an "Import gate" step between build and push: runs `python -m vllm_omni.entrypoints.cli.main serve --help` against the just-built image and fails the workflow on any `ImportError` before the image reaches the registry.
- Splits the prior `Build and push (CUDA)` step into `Build (load:true)` → `Import gate` → `Push (docker push)`. Build cache (`gha,mode=max`) and tag layout unchanged.

## Why
Closes the gap that motivated the 2026-05-09 incident response — no CI gate currently blocks bad images from reaching the registry (`pre-commit.yml` is lint-only, `build_wheel.yml` runs on `main` not `ht`, `docker-publish.yml` had no test step). This is the lightest-weight gate that would have caught the vLLM-0.20 path-validation regression class manually pre-validated during the 2026-05-12 rebase ("Pre-smoke gate: must exit 0 with no `ImportError`").

## Tradeoffs / known risks
- **Runner disk**: `load: true` requires the CUDA image to fit in the local docker daemon. The existing "Free disk space" step is already there; if the image grows past the runner's free space, we'll see disk-full failures and need a self-hosted runner. Watch the first run.
- **Scope**: This is an import gate only — not a full test gate. It catches import-time regressions (the most common kind) but not runtime/worker-death regressions. A self-hosted GPU smoke job that actually boots the model and POSTs `/v1/audio/speech` is the natural follow-up (Smoke A from the rebase protocol).
- Cache and tag behavior preserved; this should be a no-op for happy-path pushes.

## Test plan
- [ ] Workflow_dispatch this branch via the Actions tab; confirm the Import gate step runs against the just-built image and the workflow succeeds end-to-end with the same tags as before.
- [ ] Optionally, push a deliberately broken import on a throwaway branch to confirm the gate actually fails the workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)