### PR TITLE
fix(qwen3_tts): downgrade Code2Wav skip warning to debug

### DIFF
--- a/vllm_omni/model_executor/models/qwen3_tts/qwen3_tts_code2wav.py
+++ b/vllm_omni/model_executor/models/qwen3_tts/qwen3_tts_code2wav.py
@@ -147,11 +147,20 @@ class Qwen3TTSCode2Wav(nn.Module):
             n = flat.numel()
             if n == 0 or n % q != 0:
                 if n > 0:
-                    logger.warning(
-                        "Code2Wav input_ids length %d not divisible by num_quantizers %d; skipping malformed request.",
-                        n,
-                        q,
-                    )
+                    if n > q * 12:
+                        logger.warning(
+                            "Code2Wav skip: input_ids length %d not divisible by num_quantizers %d. "
+                            "This skip has persisted past the first second of output and may indicate a broken sequence.",
+                            n,
+                            q,
+                        )
+                    else:
+                        logger.debug(
+                            "Code2Wav skip: input_ids length %d not divisible by num_quantizers %d "
+                            "(expected during streaming chunk-buffer setup; non-fatal).",
+                            n,
+                            q,
+                        )
                 parsed.append((0, 0))
                 continue
             frames = n // q


### PR DESCRIPTION
Fixes #40 by downgrading the expected sub-frame warning to debug, upgrading it to a warning only if it persists past the first second of output.